### PR TITLE
Require space before blocks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,7 @@ module.exports = {
         'keyword-spacing': ['error', { before: true, after: true }],
         'semi': ['error', 'always'],
         'semi-spacing': ['error', { before: false, after: true }],
+        'space-before-blocks': 'error',
         'space-infix-ops': 'error',
         'space-unary-ops': ['warn', { words: true, nonwords: false }],
         'strict': ['error', 'global'],


### PR DESCRIPTION
`function a(){}` -> `function a() {}`

See https://eslint.org/docs/rules/space-before-blocks#options